### PR TITLE
Amenities can be added to questions

### DIFF
--- a/src/Admin.tsx
+++ b/src/Admin.tsx
@@ -87,7 +87,7 @@ export default function Admin(): JSX.Element {
         >
           <Tab label="Parking" />
           <Tab label="Users" />
-          <Tab label="Ameneties" />
+          <Tab label="Amenities" />
           <Tab label="Questions" />
           <Tab label="Reservations" />
         </Tabs>

--- a/src/QuestionAdmin.tsx
+++ b/src/QuestionAdmin.tsx
@@ -105,6 +105,14 @@ export default function QuestionAdmin(): JSX.Element {
       const index = question.amenities[Number(a)].id;
       checkedValues[index] = true;
     });
+
+    Object.keys(amenities).forEach((a) => {
+      const index = amenities[Number(a)].id;
+      if (!checkedValues[index]) {
+        checkedValues[index] = false;
+      }
+    });
+
     setAmenityChecks(checkedValues);
     setAmenityOpen(true);
   };
@@ -217,6 +225,7 @@ export default function QuestionAdmin(): JSX.Element {
                   <Checkbox
                     checked={amenityChecks[amenity.id]}
                     onChange={(e): void => handleCheckChange(e, amenity)}
+                    name={String(amenity.id)}
                     inputProps={{ 'aria-label': 'primary checkbox' }}
                   />
                 )}

--- a/src/QuestionAdmin.tsx
+++ b/src/QuestionAdmin.tsx
@@ -1,8 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import Button from '@material-ui/core/Button';
-import { AdminManager, Question } from 'condo-brain';
+import { AdminManager, Amenity, Question } from 'condo-brain';
 import { Grid } from '@material-ui/core';
 import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
+import Chip from '@material-ui/core/Chip';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogActions from '@material-ui/core/DialogActions';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -10,6 +18,7 @@ import TextField from '@material-ui/core/TextField';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
+import AddIcon from '@material-ui/icons/Add';
 
 type QuestionProp = {
   children: Question;
@@ -21,6 +30,14 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
       margin: theme.spacing(1),
       width: '100%',
     },
+  },
+  chips: {
+    '& > *': {
+      margin: theme.spacing(0.5),
+    },
+  },
+  chip: {
+    backgroundColor: '#f37f30',
   },
   registerButton: {
     backgroundColor: '#f37f30',
@@ -39,6 +56,10 @@ export default function QuestionAdmin(): JSX.Element {
   const classes = useStyles();
   const [questions, setQuestions] = useState<Question[]>([]);
   const [value, setValue] = useState('');
+  const [amenityOpen, setAmenityOpen] = useState(false);
+  const [selectedQuestion, setSelectedQuestion] = useState<Question | undefined>(undefined);
+  const [amenities, setAmenities] = useState<Amenity[]>([]);
+  const [amenityChecks, setAmenityChecks] = useState<boolean[]>([]);
 
   const admin = new AdminManager();
   if (!admin) { return (<div />); }
@@ -71,18 +92,85 @@ export default function QuestionAdmin(): JSX.Element {
     setValue(event.target.value);
   };
 
+  const fetchAmenities = async (): Promise<void> => {
+    admin.getAmenities().then((response) => {
+      setAmenities(response);
+    });
+  };
+
+  const openAmenity = (question: Question): void => {
+    setSelectedQuestion(question);
+    const checkedValues: boolean[] = [];
+    Object.keys(question.amenities).forEach((a) => {
+      const index = question.amenities[Number(a)].id;
+      checkedValues[index] = true;
+    });
+    setAmenityChecks(checkedValues);
+    setAmenityOpen(true);
+  };
+
   useEffect(() => {
     fetchQuestion();
+    fetchAmenities();
   }, [questions.length]);
+
+  const handleCheckChange = (
+    event: React.ChangeEvent<{ name?: string; checked: unknown }>,
+    amenity: Amenity,
+  ): void => {
+    const formData = new FormData();
+    if (event.target.checked) {
+      const currentAnswers = amenityChecks;
+      currentAnswers[Number(event.target.name)] = true;
+      setAmenityChecks(currentAnswers);
+      formData.append('resource_question[resource_id]', String(amenity.id));
+      formData.append('resource_question[question_id]', String(selectedQuestion?.id));
+      admin.createAmenityQuestion(formData).then(() => {
+        fetchQuestion();
+      });
+    } else {
+      const currentAnswers = amenityChecks;
+      currentAnswers[amenity.id] = false;
+      setAmenityChecks(currentAnswers);
+      formData.append('resource_question[resource_id]', String(amenity.id));
+      formData.append('resource_question[question_id]', String(selectedQuestion?.id));
+      admin.deleteAmenityQuestion(formData).then(() => {
+        fetchQuestion();
+      });
+    }
+  };
 
   const QuestionLI = (prop: QuestionProp): JSX.Element => {
     const question = prop.children;
     const primary = question.question;
+    const secondary = (
+      <div className={classes.chips}>
+        {!(question.amenities?.length > 0) && (
+          <>
+            No associated amenities.
+          </>
+        )}
+        {question.amenities && question.amenities.map((amenity) => (
+          <>
+            <Chip
+              label={amenity.name}
+              classes={{ colorPrimary: classes.chip }}
+              color="primary"
+              size="small"
+            />
+          </>
+        ))}
+        <IconButton aria-label="delete" size="small">
+          <AddIcon fontSize="inherit" onClick={(): void => openAmenity(question)} />
+        </IconButton>
+      </div>
+    );
 
     return (
       <ListItem>
         <ListItemText
           primary={primary}
+          secondary={secondary}
         />
         <ListItemSecondaryAction>
           <IconButton edge="end" aria-label="delete" onClick={(): void => { deleteQuestion(question.id); }}>
@@ -116,6 +204,34 @@ export default function QuestionAdmin(): JSX.Element {
           </List>
         </Grid>
       </Grid>
+      <Dialog open={amenityOpen} aria-labelledby="form-dialog-title">
+        <DialogTitle id="form-dialog-title">Add Associated Amenities</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {selectedQuestion?.question}
+          </DialogContentText>
+          {amenities.map((amenity): JSX.Element => (
+            <>
+              <FormControlLabel
+                control={(
+                  <Checkbox
+                    checked={amenityChecks[amenity.id]}
+                    onChange={(e): void => handleCheckChange(e, amenity)}
+                    inputProps={{ 'aria-label': 'primary checkbox' }}
+                  />
+                )}
+                label={amenity.name}
+              />
+              <br />
+            </>
+          ))}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={(): void => setAmenityOpen(false)} color="primary">
+            Done
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 }

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -47,7 +47,7 @@ export default function Resevation(): JSX.Element {
   const [amenity, setAmenity] = useState<string | unknown>(null);
   const [amenities, setAmenities] = useState<Amenity[]>([]);
   const [answers, setAnswers] = useState<boolean[]>([]);
-  const [questions, setQuestions] = useState<Question[]>([]);
+  const [questions, setQuestions] = useState<{ [id: number]: Question[] } >([]);
   const [thanks, setThanks] = useState(false);
   const [amenityTime, setAmenityTime] = useState<number>(60);
   const [errorMessage, setErrorMessage] = useState<string | unknown>(null);
@@ -82,13 +82,15 @@ export default function Resevation(): JSX.Element {
       });
   };
 
-  const fetchAmenities = async (): Promise<void> => (
-    userManager.getAmenities().then((result) => (setAmenities(result)))
-  );
-
-  const fetchQuestions = async (): Promise<void> => (
-    userManager.getQuestions().then((result) => (setQuestions(result)))
-  );
+  const fetchAmenities = async (): Promise<void> => (userManager.getAmenities().then((result) => {
+    setAmenities(result);
+    const amenityQuestions: { [id: number]: Question[] } = [];
+    Object.keys(result).forEach((i) => {
+      const a = result[Number(i)];
+      amenityQuestions[a.id] = a.questions;
+    });
+    setQuestions(amenityQuestions);
+  }));
 
   const findReservations = (): void => {
     if (!amenity || !selectedStartDate) { return; }
@@ -145,7 +147,6 @@ export default function Resevation(): JSX.Element {
 
   useEffect(() => {
     fetchAmenities();
-    fetchQuestions();
   }, [amenities.length]);
 
   useEffect(() => {
@@ -438,7 +439,7 @@ export default function Resevation(): JSX.Element {
                     />
                   )}
                 </Grid>
-                {questions.map(
+                {amenity && questions[Number(amenity)].map(
                   (questionOption) => (
                     <Grid item xs={12} key={questionOption.id}>
                       <FormControlLabel


### PR DESCRIPTION
Fixes #41 

This PR adds the ability to add amenities to questions in the admin and show them on the reservations page. 

Note that the corresponding condo-brain PR needs to be approved and merged before this passes automated checks. https://github.com/condomanagement/condo-brain/pull/27 