### PR TITLE
15 min interval

### DIFF
--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -45,9 +45,22 @@ const minutesToReadable = (t: number): string => {
   return timeText;
 };
 
+const addMinutes = (date: Date, min: number): Date => {
+  const updatedDate = new Date(date);
+  updatedDate.setMinutes(date.getMinutes() + min);
+  return updatedDate;
+};
+
 const roundToMinuteInterval = (date: Date, interval: number): Date => {
-  const roundedDate = new Date(date.getFullYear(), date.getMonth(), date.getDay(), date.getHours(),
-    Math.round(date.getMinutes() / interval) * interval);
+  const time = (date.getHours() * 60) + date.getMinutes();
+  const rounded = Math.round(time / interval) * interval;
+  const roundedDate = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    Math.floor(rounded / 60),
+    rounded % 60,
+  );
   return roundedDate;
 };
 
@@ -72,8 +85,8 @@ const formatTime = (date: Date): string => {
 };
 
 export default function Resevation(): JSX.Element {
-  const [selectedStartDate, setSelectedStartDateChange] = useState<Date>(new Date());
-  const [selectedEndDate, setSelectedEndDateChange] = useState<Date>(new Date());
+  const [selectedStartDate, setSelectedStartDateChange] = useState<Date>(roundToMinuteInterval(new Date(), 15));
+  const [selectedEndDate, setSelectedEndDateChange] = useState<Date>(addMinutes(selectedStartDate, 30));
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [amenity, setAmenity] = useState<string | unknown>(null);
   const [amenities, setAmenities] = useState<Amenity[]>([]);
@@ -290,7 +303,7 @@ export default function Resevation(): JSX.Element {
       setTime.getMinutes(),
     );
 
-    setSelectedStartDateChange(startDate);
+    setSelectedStartDateChange(roundToMinuteInterval(startDate, 15));
   };
 
   const handleNativeEndTimeChange = (date: string): void => {
@@ -320,7 +333,7 @@ export default function Resevation(): JSX.Element {
       setTime.getMinutes(),
     );
 
-    setSelectedEndDateChange(endDate);
+    setSelectedEndDateChange(roundToMinuteInterval(endDate, 15));
   };
 
   const useStyles = makeStyles((theme: Theme) => createStyles({
@@ -369,6 +382,8 @@ export default function Resevation(): JSX.Element {
                 onClick={(): void => {
                   setAvailability(null);
                   setThanks(false);
+                  setSelectedStartDateChange(roundToMinuteInterval(new Date(), 15));
+                  setSelectedEndDateChange(roundToMinuteInterval(addMinutes(selectedStartDate, 30), 15));
                 }}
                 startIcon={<EventAvailable />}
                 type="submit"

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -438,7 +438,7 @@ export default function Resevation(): JSX.Element {
                   { !isMobile && (
                     <DatePicker
                       id="start"
-                      value={roundToMinuteInterval(selectedStartDate!, 15)}
+                      value={selectedStartDate}
                       label="Date"
                       onChange={(e): void => handleDateChange(e?.toString())}
                       style={{ width: '100%' }}
@@ -461,7 +461,6 @@ export default function Resevation(): JSX.Element {
                   { !isMobile && (
                     <TimePicker
                       id="startTime"
-                      initialFocusedDate={roundToMinuteInterval(selectedStartDate!, 15)}
                       value={roundToMinuteInterval(selectedStartDate!, 15)}
                       label="Start Time"
                       onChange={(e): void => handleStartDateChange(e?.toString())}
@@ -486,7 +485,6 @@ export default function Resevation(): JSX.Element {
                   { !isMobile && (
                     <TimePicker
                       id="endTime"
-                      initialFocusedDate={roundToMinuteInterval(selectedEndDate!, 15)}
                       value={roundToMinuteInterval(selectedEndDate!, 15)}
                       label="End Time"
                       onChange={(e): void => handleEndDateChange(e?.toString())}

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -451,7 +451,6 @@ export default function Resevation(): JSX.Element {
                       id="startTime"
                       label="Start Time"
                       type="time"
-                      defaultValue={formatTime(roundToMinuteInterval(selectedStartDate!, 15))}
                       value={formatTime(roundToMinuteInterval(selectedStartDate!, 15))}
                       onChange={(e): void => handleNativeStartTimeChange(e.target.value)}
                       InputLabelProps={{
@@ -477,7 +476,6 @@ export default function Resevation(): JSX.Element {
                       id="endTime"
                       label="End Time"
                       type="time"
-                      defaultValue={formatTime(roundToMinuteInterval(selectedEndDate!, 15))}
                       value={formatTime(roundToMinuteInterval(selectedEndDate!, 15))}
                       onChange={(e): void => handleNativeEndTimeChange(e.target.value)}
                       InputLabelProps={{

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -57,10 +57,10 @@ const formatDate = (date: Date): string => {
   const year = date.toLocaleDateString().split('/')[2];
 
   if (parseInt(month, 10) < 10) {
-    month = `0 ${month}`;
+    month = `0${month}`;
   }
   if (parseInt(day, 10) < 10) {
-    day = `0 ${day}`;
+    day = `0${day}`;
   }
 
   return `${year} - ${month} - ${day}`;

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -50,6 +50,25 @@ const roundToMinuteInterval = (date: Date, interval: number): Date => {
     Math.round(date.getMinutes() / interval) * interval); 
 };
 
+const formatDate = (date: Date): string => {
+  let month = date.toLocaleDateString().split("/")[0];
+  let day = date.toLocaleDateString().split("/")[1];
+  const year = date.toLocaleDateString().split("/")[2];
+
+  if(parseInt(month) < 10) {
+    month = "0" + month; 
+  }
+  if(parseInt(day) < 10) {
+    day = "0" + day;
+  }
+
+  return year + "-" + month + "-" + day; 
+}; 
+
+const formatTime = (date: Date): string => {
+  return date.toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit'}); 
+}; 
+
 export default function Resevation(): JSX.Element {
   const [selectedStartDate, setSelectedStartDateChange] = useState<Date | null>(new Date());
   const [selectedEndDate, setSelectedEndDateChange] = useState<Date | null>(new Date());
@@ -409,7 +428,7 @@ export default function Resevation(): JSX.Element {
                       id="start"
                       label="Date"
                       type="date"
-                      defaultValue={roundToMinuteInterval(selectedStartDate!, 15)}
+                      defaultValue={formatDate(selectedStartDate!)}
                       onChange={(e): void => handleNativeDateChange(e.target.value)}
                       InputLabelProps={{
                         shrink: true,
@@ -432,7 +451,8 @@ export default function Resevation(): JSX.Element {
                       id="startTime"
                       label="Start Time"
                       type="time"
-                      defaultValue={roundToMinuteInterval(selectedStartDate!, 15)}
+                      defaultValue={formatTime(roundToMinuteInterval(selectedStartDate!, 15))}
+                      value={formatTime(roundToMinuteInterval(selectedStartDate!, 15))}
                       onChange={(e): void => handleNativeStartTimeChange(e.target.value)}
                       InputLabelProps={{
                         shrink: true,
@@ -457,7 +477,8 @@ export default function Resevation(): JSX.Element {
                       id="endTime"
                       label="End Time"
                       type="time"
-                      defaultValue={roundToMinuteInterval(selectedEndDate!, 15)}
+                      defaultValue={formatTime(roundToMinuteInterval(selectedEndDate!, 15))}
+                      value={formatTime(roundToMinuteInterval(selectedEndDate!, 15))}
                       onChange={(e): void => handleNativeEndTimeChange(e.target.value)}
                       InputLabelProps={{
                         shrink: true,

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -45,6 +45,11 @@ const minutesToReadable = (t: number): string => {
   return timeText;
 };
 
+const roundToMinuteInterval = (date: Date, interval: number): Date => {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDay(), date.getHours(), 
+    Math.round(date.getMinutes() / interval) * interval); 
+};
+
 export default function Resevation(): JSX.Element {
   const [selectedStartDate, setSelectedStartDateChange] = useState<Date | null>(new Date());
   const [selectedEndDate, setSelectedEndDateChange] = useState<Date | null>(new Date());
@@ -404,7 +409,7 @@ export default function Resevation(): JSX.Element {
                       id="start"
                       label="Date"
                       type="date"
-                      defaultValue={selectedStartDate}
+                      defaultValue={roundToMinuteInterval(selectedStartDate!, 15)}
                       onChange={(e): void => handleNativeDateChange(e.target.value)}
                       InputLabelProps={{
                         shrink: true,
@@ -414,7 +419,7 @@ export default function Resevation(): JSX.Element {
                   { !isMobile && (
                     <DatePicker
                       id="start"
-                      value={selectedStartDate}
+                      value={roundToMinuteInterval(selectedStartDate!, 15)}
                       label="Date"
                       onChange={(e): void => handleDateChange(e?.toString())}
                       style={{ width: '100%' }}
@@ -427,7 +432,7 @@ export default function Resevation(): JSX.Element {
                       id="startTime"
                       label="Start Time"
                       type="time"
-                      defaultValue={selectedStartDate}
+                      defaultValue={roundToMinuteInterval(selectedStartDate!, 15)}
                       onChange={(e): void => handleNativeStartTimeChange(e.target.value)}
                       InputLabelProps={{
                         shrink: true,
@@ -437,10 +442,12 @@ export default function Resevation(): JSX.Element {
                   { !isMobile && (
                     <TimePicker
                       id="startTime"
-                      value={selectedStartDate}
+                      initialFocusedDate={roundToMinuteInterval(selectedStartDate!, 15)}
+                      value={roundToMinuteInterval(selectedStartDate!, 15)}
                       label="Start Time"
                       onChange={(e): void => handleStartDateChange(e?.toString())}
                       style={{ width: '100%' }}
+                      minutesStep={15}
                     />
                   )}
                 </Grid>
@@ -450,7 +457,7 @@ export default function Resevation(): JSX.Element {
                       id="endTime"
                       label="End Time"
                       type="time"
-                      defaultValue={selectedEndDate}
+                      defaultValue={roundToMinuteInterval(selectedEndDate!, 15)}
                       onChange={(e): void => handleNativeEndTimeChange(e.target.value)}
                       InputLabelProps={{
                         shrink: true,
@@ -460,10 +467,12 @@ export default function Resevation(): JSX.Element {
                   { !isMobile && (
                     <TimePicker
                       id="endTime"
-                      value={selectedEndDate}
+                      initialFocusedDate={roundToMinuteInterval(selectedEndDate!, 15)}
+                      value={roundToMinuteInterval(selectedEndDate!, 15)}
                       label="End Time"
                       onChange={(e): void => handleEndDateChange(e?.toString())}
                       style={{ width: '100%' }}
+                      minutesStep={15}
                     />
                   )}
                 </Grid>

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -46,33 +46,35 @@ const minutesToReadable = (t: number): string => {
 };
 
 const roundToMinuteInterval = (date: Date, interval: number): Date => {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDay(), date.getHours(), 
-    Math.round(date.getMinutes() / interval) * interval); 
+  const roundedDate = new Date(date.getFullYear(), date.getMonth(), date.getDay(), date.getHours(),
+    Math.round(date.getMinutes() / interval) * interval);
+  return roundedDate;
 };
 
 const formatDate = (date: Date): string => {
-  let month = date.toLocaleDateString().split("/")[0];
-  let day = date.toLocaleDateString().split("/")[1];
-  const year = date.toLocaleDateString().split("/")[2];
+  let month = date.toLocaleDateString().split('/')[0];
+  let day = date.toLocaleDateString().split('/')[1];
+  const year = date.toLocaleDateString().split('/')[2];
 
-  if(parseInt(month) < 10) {
-    month = "0" + month; 
+  if (parseInt(month, 10) < 10) {
+    month = `0 ${month}`;
   }
-  if(parseInt(day) < 10) {
-    day = "0" + day;
+  if (parseInt(day, 10) < 10) {
+    day = `0 ${day}`;
   }
 
-  return year + "-" + month + "-" + day; 
-}; 
+  return `${year} - ${month} - ${day}`;
+};
 
 const formatTime = (date: Date): string => {
-  return date.toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit'}); 
-}; 
+  const options = { hour12: false, hour: '2-digit', minute: '2-digit' };
+  return date.toLocaleTimeString([], options);
+};
 
 export default function Resevation(): JSX.Element {
-  const [selectedStartDate, setSelectedStartDateChange] = useState<Date | null>(new Date());
-  const [selectedEndDate, setSelectedEndDateChange] = useState<Date | null>(new Date());
-  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
+  const [selectedStartDate, setSelectedStartDateChange] = useState<Date>(new Date());
+  const [selectedEndDate, setSelectedEndDateChange] = useState<Date>(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [amenity, setAmenity] = useState<string | unknown>(null);
   const [amenities, setAmenities] = useState<Amenity[]>([]);
   const [answers, setAnswers] = useState<boolean[]>([]);
@@ -428,7 +430,7 @@ export default function Resevation(): JSX.Element {
                       id="start"
                       label="Date"
                       type="date"
-                      defaultValue={formatDate(selectedStartDate!)}
+                      defaultValue={formatDate(selectedStartDate)}
                       onChange={(e): void => handleNativeDateChange(e.target.value)}
                       InputLabelProps={{
                         shrink: true,
@@ -451,7 +453,7 @@ export default function Resevation(): JSX.Element {
                       id="startTime"
                       label="Start Time"
                       type="time"
-                      value={formatTime(roundToMinuteInterval(selectedStartDate!, 15))}
+                      value={formatTime(roundToMinuteInterval(selectedStartDate, 15))}
                       onChange={(e): void => handleNativeStartTimeChange(e.target.value)}
                       InputLabelProps={{
                         shrink: true,
@@ -461,7 +463,7 @@ export default function Resevation(): JSX.Element {
                   { !isMobile && (
                     <TimePicker
                       id="startTime"
-                      value={roundToMinuteInterval(selectedStartDate!, 15)}
+                      value={roundToMinuteInterval(selectedStartDate, 15)}
                       label="Start Time"
                       onChange={(e): void => handleStartDateChange(e?.toString())}
                       style={{ width: '100%' }}
@@ -475,7 +477,7 @@ export default function Resevation(): JSX.Element {
                       id="endTime"
                       label="End Time"
                       type="time"
-                      value={formatTime(roundToMinuteInterval(selectedEndDate!, 15))}
+                      value={formatTime(roundToMinuteInterval(selectedEndDate, 15))}
                       onChange={(e): void => handleNativeEndTimeChange(e.target.value)}
                       InputLabelProps={{
                         shrink: true,
@@ -485,7 +487,7 @@ export default function Resevation(): JSX.Element {
                   { !isMobile && (
                     <TimePicker
                       id="endTime"
-                      value={roundToMinuteInterval(selectedEndDate!, 15)}
+                      value={roundToMinuteInterval(selectedEndDate, 15)}
                       label="End Time"
                       onChange={(e): void => handleEndDateChange(e?.toString())}
                       style={{ width: '100%' }}

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -71,23 +71,6 @@ const formatTime = (date: Date): string => {
   return date.toLocaleTimeString([], options);
 };
 
-const formatDate = (date: Date): string => {
-  let month = date.toLocaleDateString().split('/')[0];
-  let day = date.toLocaleDateString().split('/')[1];
-  const year = date.toLocaleDateString().split('/')[2];
-
-  if (parseInt(month) < 10) {
-    month = `0${month}`;
-  }
-  if (parseInt(day) < 10) {
-    day = `0${day}`;
-  }
-
-  return `${year}-${month}-${day}`;
-};
-
-const formatTime = (date: Date): string => date.toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit' });
-
 export default function Resevation(): JSX.Element {
   const [selectedStartDate, setSelectedStartDateChange] = useState<Date>(new Date());
   const [selectedEndDate, setSelectedEndDateChange] = useState<Date>(new Date());

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -71,6 +71,23 @@ const formatTime = (date: Date): string => {
   return date.toLocaleTimeString([], options);
 };
 
+const formatDate = (date: Date): string => {
+  let month = date.toLocaleDateString().split('/')[0];
+  let day = date.toLocaleDateString().split('/')[1];
+  const year = date.toLocaleDateString().split('/')[2];
+
+  if (parseInt(month) < 10) {
+    month = `0${month}`;
+  }
+  if (parseInt(day) < 10) {
+    day = `0${day}`;
+  }
+
+  return `${year}-${month}-${day}`;
+};
+
+const formatTime = (date: Date): string => date.toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit' });
+
 export default function Resevation(): JSX.Element {
   const [selectedStartDate, setSelectedStartDateChange] = useState<Date>(new Date());
   const [selectedEndDate, setSelectedEndDateChange] = useState<Date>(new Date());

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -115,7 +115,7 @@ export default function Resevation(): JSX.Element {
               {'  '}
               Availability
             </AlertTitle>
-            Available all day.
+            No current bookings.
             <p>
               {minutesToReadable(amenityTime)}
               {'  '}

--- a/src/Reservation.tsx
+++ b/src/Reservation.tsx
@@ -63,7 +63,7 @@ const formatDate = (date: Date): string => {
     day = `0${day}`;
   }
 
-  return `${year} - ${month} - ${day}`;
+  return `${year}-${month}-${day}`;
 };
 
 const formatTime = (date: Date): string => {
@@ -273,7 +273,7 @@ export default function Resevation(): JSX.Element {
       Number(minute),
     );
 
-    setSelectedStartDateChange(startDate);
+    setSelectedStartDateChange(roundToMinuteInterval(startDate, 15));
   };
 
   const handleStartDateChange = (date: string | undefined): void => {
@@ -303,7 +303,7 @@ export default function Resevation(): JSX.Element {
       Number(minute),
     );
 
-    setSelectedEndDateChange(endDate);
+    setSelectedEndDateChange(roundToMinuteInterval(endDate, 15));
   };
 
   const handleEndDateChange = (date: string | undefined): void => {


### PR DESCRIPTION
Closes #40 
Closes #59 

Changes: 
* Snapping on web to 15 minute intervals 
* Formatting for mobile so that default values show
* Automatic rounding on mobile to 15 minute intervals (dial shows all minutes, but when user selects a minute, it will round immediately) 
* Text change from "Available all day" to "No current bookings" 
