### PR TITLE
Login and inactive users

### DIFF
--- a/src/Nav.tsx
+++ b/src/Nav.tsx
@@ -330,7 +330,7 @@ export default function NavBar({ userManager }: { userManager: UserManager }): J
             color="inherit"
             href="/login"
           >
-            Login
+            Amenities reservation login
           </Button>
         </Toolbar>
       </AppBar>

--- a/src/UserAdmin.tsx
+++ b/src/UserAdmin.tsx
@@ -213,7 +213,10 @@ export default function UserAdmin(): JSX.Element {
                 style={{ display: 'inline' }}
                 color="textPrimary"
               >
+                ,
+                {'  '}
                 {`${user.email}`}
+
               </Typography>
               {user.active && (
                 <Typography
@@ -222,6 +225,7 @@ export default function UserAdmin(): JSX.Element {
                   style={{ display: 'inline' }}
                   color="textPrimary"
                 >
+                  ,
                   {'  '}
                   Active
                 </Typography>
@@ -233,6 +237,7 @@ export default function UserAdmin(): JSX.Element {
                   style={{ display: 'inline' }}
                   color="textPrimary"
                 >
+                  ,
                   {'  '}
                   Inactive
                 </Typography>

--- a/src/UserAdmin.tsx
+++ b/src/UserAdmin.tsx
@@ -193,7 +193,7 @@ export default function UserAdmin(): JSX.Element {
     const primary = user.name;
 
     return (
-      <ListItem>
+      <ListItem disabled={!user.active}>
         <ListItemText
           primary={primary}
           secondary={(
@@ -207,7 +207,14 @@ export default function UserAdmin(): JSX.Element {
                 {`${user.unit}`}
                 {'  '}
               </Typography>
-              {`${user.email}`}
+              <Typography
+                component="span"
+                variant="body2"
+                style={{ display: 'inline' }}
+                color="textPrimary"
+              >
+                {`${user.email}`}
+              </Typography>
               {user.active && (
                 <Typography
                   component="span"
@@ -379,7 +386,6 @@ export default function UserAdmin(): JSX.Element {
       </Dialog>
     </form>
   );
-
 
   useEffect(() => {
     fetchUsers();


### PR DESCRIPTION
Changes:
* Change the login button to say: Amenities reservation login
* For inactive users make the text grey in the admin
* Add formatting to email, so the styles are consistent 
* Add commas for better spacing 

After adding the commas for spacing, I noticed that when "Hide inactive users" is off, there is an empty user shown at the top, is that expected/desired?   
