### PR TITLE
Add catchall path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Build application
         run: |
+          rm -rf server-dist build
           npm run build
           npm run build-server
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import cors, { CorsOptions } from 'cors';
 import express, { Express } from 'express';
 import rateLimit from 'express-rate-limit';
@@ -66,6 +67,11 @@ async function createServer(): Promise<Express> {
 
   app.all('/healthcheck', (req, res) => {
     apiProxy.web(req, res, { target: 'https://api.arrowlofts.org', secure: true });
+  });
+
+  // Serve index.html for all other routes (client-side routing)
+  app.use((_req, res) => {
+    res.sendFile(path.join(__dirname, '../build/index.html'));
   });
 
   return app;


### PR DESCRIPTION
This pull request adds support for client-side routing by ensuring that all non-API routes serve the `index.html` file. This allows the frontend application to handle navigation for routes that are not explicitly defined on the server.